### PR TITLE
Endpoints to get followers and following for user

### DIFF
--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -1,5 +1,7 @@
 import { Octokit } from "@octokit/rest"
 
+export type SORT = "followers" | "repositories" | "joined" | undefined
+export type ORDER = "desc" | "asc" | undefined
 export class GithubClient {
     octokit
 
@@ -8,14 +10,45 @@ export class GithubClient {
     }
 
     /**
-     * 
-     * 
      * @param q 
      * @see https://octokit.github.io/rest.js/v18#search-users
      */
-    async getUsers({ q }: { q: string }) {
+    async getUsers({ q, sort, order, per_page, page }: 
+    { 
+        q: string
+        sort?: SORT
+        order?: ORDER
+        per_page?: number | undefined 
+        page?: number | undefined
+    }) {
         return this.octokit.search.users({
-            q
+            q,
+            sort,
+            order,
+            per_page,
+            page
+        })
+    }
+
+    /**
+     * @param param0 
+     * @see https://octokit.github.io/rest.js/v18#users-list-followers-for-user
+     * @returns 
+     */
+    async getFollowersForUser({ username }: { username: string }) {
+        return this.octokit.rest.users.listFollowersForUser({
+            username
+        })
+    }
+
+    /**
+     * @param param0 
+     * @see https://octokit.github.io/rest.js/v18#users-list-following-for-user
+     * @returns 
+     */
+    async getFollowingForUser({ username }: { username: string }) {
+        return this.octokit.rest.users.listFollowingForUser({
+            username
         })
     }
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,7 @@
 import express from "express"
 import { getGithubUsers } from "./route-handlers"
+import { getFollowersForUser } from "./route-handlers/getFollowersForUser"
+import { getFollowingForUser } from "./route-handlers/getFollowingForUsers"
 
 var app = express()
 
@@ -7,6 +9,8 @@ app.use(express.urlencoded())
 app.use(express.json())
 
 app.get(`/users`, getGithubUsers)
+app.get(`/user/followers`, getFollowersForUser)
+app.get(`/user/following`, getFollowingForUser)
 
 export function initServer() {
     app.listen(3000)

--- a/src/server/route-handlers/getFollowersForUser.ts
+++ b/src/server/route-handlers/getFollowersForUser.ts
@@ -1,0 +1,24 @@
+import express from "express"
+import { githubClient } from "../../constants"
+
+export function getFollowersForUser(
+  req: express.Request,
+  res: express.Response
+) {
+    const {
+        username
+    } = req.query
+
+    try {
+        githubClient.getFollowersForUser({
+            username: username as string
+        })
+        .then(followersRes => {
+            res.send(followersRes.data)
+        })
+    } catch (e) {
+        res.send({
+            error: e.message
+        })
+    }
+}

--- a/src/server/route-handlers/getFollowingForUsers.ts
+++ b/src/server/route-handlers/getFollowingForUsers.ts
@@ -1,0 +1,25 @@
+import express from "express"
+import { githubClient } from "../../constants"
+
+export function getFollowingForUser(
+  req: express.Request,
+  res: express.Response
+) {
+    const {
+        username
+    } = req.query
+
+    try {
+        githubClient.getFollowingForUser({
+            username: username as string
+        })
+        .then(followingRes => {
+            res.send(followingRes.data)
+        })
+    } catch (e) {
+        res.send({
+            error: e.message
+        })
+    }
+    
+}

--- a/src/server/route-handlers/getGithubUsers.ts
+++ b/src/server/route-handlers/getGithubUsers.ts
@@ -1,12 +1,19 @@
 import express from "express"
 import { githubClient, USER_QUALIFIER } from "../../constants"
+import { ORDER, SORT } from "../../github/client"
 import { UserSearchResultResponse } from "../types"
 
 export function getGithubUsers(
   req: express.Request,
   res: express.Response
 ) {
-    const { query } = req.query
+    const { 
+        query,
+        sort,
+        order,
+        per_page,
+        page 
+    } = req.query
 
     try {
         let userQuery: string
@@ -16,7 +23,14 @@ export function getGithubUsers(
             userQuery = query + USER_QUALIFIER
         }
 
-        return githubClient.getUsers({ q: userQuery })
+        return githubClient.getUsers(
+            { 
+                q: userQuery, 
+                sort: sort as SORT,
+                order: order as ORDER,
+                per_page: per_page as number | undefined,
+                page: page as number | undefined,
+            })
             .then(response => {
                 const users = response.data as UserSearchResultResponse
                 res.send(users)


### PR DESCRIPTION
# Description

Adds endpoints to get followers and following for a specified user.

## Testing

### Get followers for user
1. Run the application
2. In the browser (or postman), send a GET to `http://localhost:3000/user/followers?username=<USER_NAME>`

### Get following for users
1. Run the application
2. In the browser (or postman), send a GET to `http://localhost:3000/user/following?username=<USER_NAME>`